### PR TITLE
use pkg-config in configure to locate varnishd and varnishtest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ Makefile.in
 
 /src/vcc_if.c
 /src/vcc_if.h
+/src/vmod_urlcode.man.rst
+/src/vmod_urlcode.rst
 /vmod_urlcode.3
 /nbproject/private/
 

--- a/configure.ac
+++ b/configure.ac
@@ -44,8 +44,32 @@ VARNISH_VMOD_INCLUDES
 VARNISH_VMOD_DIR
 VARNISH_VMODTOOL
 
-AC_PATH_PROG([VARNISHTEST], [varnishtest])
-AC_PATH_PROG([VARNISHD], [varnishd])
+# backwards compat with older pkg-config
+# - pull in AC_DEFUN from pkg.m4
+m4_ifndef([PKG_CHECK_VAR], [
+# PKG_CHECK_VAR(VARIABLE, MODULE, CONFIG-VARIABLE,
+# [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+# -------------------------------------------
+# Retrieves the value of the pkg-config variable for the given module.
+AC_DEFUN([PKG_CHECK_VAR],
+[AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
+AC_ARG_VAR([$1], [value of $3 for $2, overriding pkg-config])dnl
+
+_PKG_CONFIG([$1], [variable="][$3]["], [$2])
+AS_VAR_COPY([$1], [pkg_cv_][$1])
+
+AS_VAR_IF([$1], [""], [$5], [$4])dnl
+])# PKG_CHECK_VAR
+])
+
+PKG_CHECK_MODULES([libvarnishapi], [varnishapi])
+PKG_CHECK_VAR([LIBVARNISHAPI_BINDIR], [varnishapi], [bindir])
+PKG_CHECK_VAR([LIBVARNISHAPI_SBINDIR], [varnishapi], [sbindir])
+
+AC_PATH_PROG([VARNISHTEST], [varnishtest], [],
+    [$LIBVARNISHAPI_BINDIR:$LIBVARNISHAPI_SBINDIR:$PATH])
+AC_PATH_PROG([VARNISHD], [varnishd], [],
+    [$LIBVARNISHAPI_SBINDIR:$LIBVARNISHAPI_BINDIR:$PATH])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,7 +17,8 @@ VMOD_TESTS = tests/*.vtc
 .PHONY: $(VMOD_TESTS)
 
 tests/*.vtc:
-	@VARNISHTEST@ -Dvarnishd=@VARNISHD@ -Dvmod_topbuild=$(abs_top_builddir) $@
+	PATH=@LIBVARNISHAPI_SBINDIR@:$$PATH \
+	@VARNISHTEST@ -Dvmod_topbuild=$(abs_top_builddir) $@
 
 check: $(VMOD_TESTS)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,22 +5,24 @@ vmod_LTLIBRARIES = libvmod_urlcode.la
 
 libvmod_urlcode_la_LDFLAGS = -module -export-dynamic -avoid-version
 
-libvmod_urlcode_la_SOURCES = \
-	vcc_if.c \
-	vcc_if.h \
-	vmod_urlcode.c
+libvmod_urlcode_la_SOURCES = vmod_urlcode.c
 
-vcc_if.c vcc_if.h: @VMODTOOL@ $(top_srcdir)/src/vmod_urlcode.vcc
+nodist_libvmod_urlcode_la_SOURCES = \
+	vcc_if.c \
+	vcc_if.h
+
+vmod_urlcode.c: vcc_if.h
+
+vmod_selector.lo: $(nodist_libvmod_selector_la_SOURCES)
+
+vcc_if.h: vcc_if.c
+
+vcc_if.c: vmod_urlcode.vcc
 	@VMODTOOL@ $(top_srcdir)/src/vmod_urlcode.vcc
 
-VMOD_TESTS = tests/*.vtc
-.PHONY: $(VMOD_TESTS)
-
-tests/*.vtc:
+check:
 	PATH=@LIBVARNISHAPI_SBINDIR@:$$PATH \
-	@VARNISHTEST@ -Dvmod_topbuild=$(abs_top_builddir) $@
-
-check: $(VMOD_TESTS)
+	@VARNISHTEST@ -Dvmod_topbuild=$(abs_top_builddir) $(srcdir)/tests/*.vtc
 
 EXTRA_DIST = \
 	vmod_urlcode.vcc \

--- a/src/vmod_urlcode.c
+++ b/src/vmod_urlcode.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 
-#include "vrt.h"
 #include "cache/cache.h"
 
 #include "vcc_if.h"

--- a/src/vmod_urlcode.c
+++ b/src/vmod_urlcode.c
@@ -19,7 +19,7 @@ vmod_encode(const struct vrt_ctx *ctx, const char *str, ...)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
-	u = WS_Reserve(ctx->ws, 0);
+	u = WS_ReserveAll(ctx->ws);
 	e = b = ctx->ws->f;
 	e += u;
 	va_start(ap, str);
@@ -77,7 +77,7 @@ vmod_decode(const struct vrt_ctx *ctx, const char *str, ...)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
-	u = WS_Reserve(ctx->ws, 0);
+	u = WS_ReserveAll(ctx->ws);
 	e = b = ctx->ws->f;
 	e += u;
 	va_start(ap, str);


### PR DESCRIPTION
'make check' failed on my first attempt to build against soon-to-be-4.1 (i.e. Varnish trunk as of 2015-08-18), because varnishd was not found in the install tree. This change makes use of pkg-config to determine Varnish's sbindir and bindir, and then locate varnishd and varnishtest.
